### PR TITLE
Basic Fedora 24 Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ fetch_sources:
 	spectool -g -S -C sources/ specs/libfdk-aac.spec
 	spectool -g -S -C sources/ specs/libmad.spec
 	spectool -g -S -C sources/ specs/libmfx.spec
+	spectool -g -S -C sources/ specs/libmpeg2.spec
 	spectool -g -S -C sources/ specs/libvo-aacenc.spec
 	spectool -g -S -C sources/ specs/libvo-amrwbenc.spec
 	spectool -g -S -C sources/ specs/libxvidcore.spec
@@ -58,6 +59,7 @@ build_srpms: fetch_sources
 	mock -q --buildsrpm --sources sources/ --resultdir build/source --spec specs/libfdk-aac.spec
 	mock -q --buildsrpm --sources sources/ --resultdir build/source --spec specs/libmad.spec
 	mock -q --buildsrpm --sources sources/ --resultdir build/source --spec specs/libmfx.spec
+	mock -q --buildsrpm --sources sources/ --resultdir build/source --spec specs/libmpeg2.spec
 	mock -q --buildsrpm --sources sources/ --resultdir build/source --spec specs/libvo-aacenc.spec
 	mock -q --buildsrpm --sources sources/ --resultdir build/source --spec specs/libvo-amrwbenc.spec
 	mock -q --buildsrpm --sources sources/ --resultdir build/source --spec specs/libxvidcore.spec
@@ -72,32 +74,32 @@ build-stepmania-srpm:
 
 build_rpms:
 	# build i686 RPMS
-	mockchain -r fedora-23-i386 -l build --recurse build/source/*.src.rpm
+	mockchain -r fedora-24-i386 -l build --recurse build/source/*.src.rpm
 	# build x86_64 RPMS
-	mockchain -r fedora-23-x86_64 -l build --recurse build/source/*.src.rpm
+	mockchain -r fedora-24-x86_64 -l build --recurse build/source/*.src.rpm
 
 build-stepmania-rpm: build-stepmania-rpm-i386 build-stepmania-rpm-x86_64
 
 build-stepmania-rpm-i386:
-	mock -r build/configs/fedora-23-i386/fedora-23-i386.cfg --rebuild build/source/stepmania-5.0.10-?.fc23.src.rpm
+	mock -r build/configs/fedora-24-i386/fedora-24-i386.cfg --rebuild build/source/stepmania-5.0.10-?.fc24.src.rpm
 
 build-stepmania-rpm-x86_64:
-	mock -r build/configs/fedora-23-x86_64/fedora-23-x86_64.cfg --rebuild build/source/stepmania-5.0.10-?.fc23.src.rpm
+	mock -r build/configs/fedora-24-x86_64/fedora-24-x86_64.cfg --rebuild build/source/stepmania-5.0.10-?.fc24.src.rpm
 
 deploy_repo:
 	# copy all rpms into the repo folder
-	test -d build/repo/fedora-23 || mkdir -p build/repo/fedora-23
-	find build/results/fedora-23-i386 build/results/fedora-23-x86_64 -type f -iname '*.rpm' \
-		-exec cp {} build/repo/fedora-23 \;
+	test -d build/repo/fedora-24 || mkdir -p build/repo/fedora-24
+	find build/results/fedora-24-i386 build/results/fedora-24-x86_64 -type f -iname '*.rpm' \
+		-exec cp {} build/repo/fedora-24 \;
 
 gen_repo_metadata:
-	( cd build/repo/fedora-23 && createrepo . )
+	( cd build/repo/fedora-24 && createrepo . )
 
 prune_repo:
 	prune-rpm-repo -v --config prune-repo.yml build/repo/ build/source/ build/results
 
 sign_rpms:
-	find build/repo -type f -iname '*.rpm' -exec rpmsign -D "_gpg_name $(GPG_KEY_ID)" --addsign {} \;
+	find build/repo -type f -iname '*.rpm' | xargs rpmsign -D "_gpg_name $(GPG_KEY_ID)" --addsign
 
 clean_build:
 	find build -mindepth 1 -maxdepth 1 -not -iname '.gitignore' -exec rm -fr {} \;

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,18 +6,20 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  config.vm.define "fedora23" do |fedora23|
+  config.vm.define "fedora24" do |fedora24|
 #   create a Fedora 23 box for building Fedora 23 packages
-    fedora23.vm.box = "fedora/fedora-cloud-23"
-    fedora23.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/23/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-23-20151030.x86_64.vagrant-virtualbox.box"
-    fedora23.vm.hostname = "fedora23"
+    fedora24.vm.box = "fedora/fedora-cloud-24"
+    fedora24.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/24/CloudImages/x86_64/images/Fedora-Cloud-Base-Vagrant-24-1.2.x86_64.vagrant-virtualbox.box"
+    fedora24.vm.hostname = "fedora24"
 
-    fedora23.vm.provision "ansible_local" do |ansible|
+    fedora24.vm.provision "shell", inline: "dnf install -y bash-completion make gcc python-2.7.11 libselinux-python python2-dnf python-devel"
+
+    fedora24.vm.provision "ansible" do |ansible|
       ansible.playbook = "ansible/vagrant.yml"
       ansible.sudo = true
     end
 
-    fedora23.vm.synced_folder ".", "/vagrant", type: "virtualbox"
+    fedora24.vm.synced_folder ".", "/vagrant", type: "virtualbox"
   end
 
   # Create a private network, which allows host-only access to the machine
@@ -26,10 +28,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provider "virtualbox" do |vb|
     # Use VBoxManage to customize the VM. For example to change memory:
-    vb.customize ["modifyvm", :id, "--memory", "2048"]
-
-    # use host cores - 2 for the box
-    host_cores = `grep -i "^processor" /proc/cpuinfo | wc -l`.strip.to_i
-    vb.customize ["modifyvm", :id, "--cpus", [host_cores - 2, 1].max]
+    vb.customize ["modifyvm", :id, "--memory", "4096"]
+    # 8 VCPUs
+    vb.customize ["modifyvm", :id, "--cpus", "8"]
   end
 end

--- a/prune-repo.yml
+++ b/prune-repo.yml
@@ -1,4 +1,4 @@
 ---
 preserve:
     - pattern: .*
-      min-versions: 1
+      min-versions: 2

--- a/sources/handbrake-patch-0001-libav-pic.patch
+++ b/sources/handbrake-patch-0001-libav-pic.patch
@@ -1,0 +1,12 @@
+diff --git a/contrib/ffmpeg/module.defs b/contrib/ffmpeg/module.defs
+index dfd6ec9..6610441 100644
+--- a/contrib/ffmpeg/module.defs
++++ b/contrib/ffmpeg/module.defs
+@@ -35,6 +35,7 @@ FFMPEG.CONFIGURE.extra = \
+     --disable-network \
+     --disable-hwaccels \
+     --disable-encoders \
++    --enable-pic \
+     --enable-libmp3lame \
+     --enable-encoder=aac \
+     --enable-encoder=ac3 \

--- a/specs/gstreamer-plugins-ugly.spec
+++ b/specs/gstreamer-plugins-ugly.spec
@@ -2,7 +2,7 @@
 
 %define package_name gstreamer-plugins-ugly
 %define package_version 0.10.19
-%define package_release 4
+%define package_release 5
 
 Name: %{package_name}
 Version: %{package_version}
@@ -51,7 +51,6 @@ Ugly GStreamer plugins.
 %configure \
     --enable-shared \
     --enable-debug \
-    --enable-gtk-doc \
     --disable-static \
     --disable-rpath \
     --with-pic
@@ -91,15 +90,10 @@ find %{buildroot} -iname '*.so' | sort | while read file ; do
     checksec --file $file
 done
 
-%package devel
-Summary: Development stuff.
-Requires: %{name} >= %{version}
-%description devel
-Development stuff.
-%files devel
-%{_datadir}/gtk-doc/html/gst-plugins-ugly-plugins-0.10/*
-
 %changelog
+* Sun Jul 17 2016 Naftuli Tzvi Kay <rfkrocktk@gmail.com> - 0.10.19-5
+- Repackage for Fedora 24, remove docs because they were breaking the build.
+
 * Sun Mar 13 2016 Naftuli Tzvi Kay <rfkrocktk@gmail.com> - 0.10.19-4
 - Rebuild on older libdvdcss.
 

--- a/specs/gstreamer1-plugins-libav.spec
+++ b/specs/gstreamer1-plugins-libav.spec
@@ -1,7 +1,7 @@
 %global _hardened_build 1
 
 %define package_name gstreamer1-plugins-libav
-%define package_version 1.6.3
+%define package_version 1.8.2
 %define package_release 1
 
 Name: %{package_name}
@@ -9,7 +9,7 @@ Version: %{package_version}
 Release: %{package_release}%{?dist}
 Summary: Ugly GStreamer plugins.
 License: LGPL, but worse.
-Source: https://gstreamer.freedesktop.org/src/gst-libav/gst-libav-1.6.3.tar.xz
+Source: https://gstreamer.freedesktop.org/src/gst-libav/gst-libav-%{package_version}.tar.xz
 URL: https://gstreamer.freedesktop.org/modules/gst-plugins-ugly.html
 
 BuildRequires: gettext-devel
@@ -67,5 +67,8 @@ Development stuff.
 %{_datadir}/gtk-doc/html/gst-libav-plugins-1.0/*
 
 %changelog
+* Sun Jul 17 2016 Naftuli Tzvi Kay <rfkrocktk@gmail.com> - 1.8.2-1
+  Repackage for Fedora 24.
+
 * Wed Feb 17 2016 Naftuli Tzvi Kay <rfkrocktk@gmail.com> - 1.6.3-1
 - Initial packaging.

--- a/specs/gstreamer1-plugins-ugly.spec
+++ b/specs/gstreamer1-plugins-ugly.spec
@@ -1,8 +1,8 @@
 %global _hardened_build 1
 
 %define package_name gstreamer1-plugins-ugly
-%define package_version 1.6.3
-%define package_release 4
+%define package_version 1.8.2
+%define package_release 1
 
 Name: %{package_name}
 Version: %{package_version}
@@ -94,6 +94,9 @@ Development stuff.
 %{_datadir}/gtk-doc/html/gst-plugins-ugly-plugins-1.0/*
 
 %changelog
+* Sun Jul 17 2016 Naftuli Tzvi Kay <rfkrocktk@gmail.com> - 1.8.2-1
+- Rebuild for Fedora 24.
+
 * Sun Mar 13 2016 Naftuli Tzvi Kay <rfkrocktk@gmail.com> - 1.6.3-4
 - Rebuild on older libdvdcss.
 

--- a/specs/libfdk-aac.spec
+++ b/specs/libfdk-aac.spec
@@ -2,7 +2,7 @@
 
 %define package_name libfdk-aac
 %define package_version 0.1.4
-%define package_release 2
+%define package_release 3
 
 Name:           %{package_name}
 Version:        %{package_version}
@@ -20,6 +20,11 @@ Advanced Audio Coding Decoder/Encoder Library.
 %setup -n fdk-aac-%{package_version}
 
 %build
+
+# on newer versions of gcc, -Wnarrowing is passed, breaking package building
+%if 0%{?fedora} > 23 || 0%{?rhel} > 8
+export CXXFLAGS="%{optflags} -Wno-narrowing"
+%endif
 
 %configure --disable-static
 
@@ -50,6 +55,9 @@ developing applications that use libfdk-aac.
 %{_libdir}/pkgconfig/fdk-aac.pc
 
 %changelog
+* Sun Jul 17 2016 Naftuli Tzvi Kay <rfkrocktk@gmail.com> - 0.1.4-3
+- Repackage for Fedora 24, thanks to negativo17.org for fix.
+
 * Wed Feb 03 2016 Naftuli Tzvi Kay <rfkrocktk@gmail.com> - 0.1.4-2
 - Moved the shared object symlink to the devel package as expected.
 


### PR DESCRIPTION
More than a few things don't work.

Not compiling at all:
- handbrake
- handbrake-legacy

Segfaulting;
- stepmania :disappointed:

Irrelevant?
- libfdk-aac
- aacplusenc
- libvo-aacenc
- opencore-amr?

Most libraries requiring an AAC encoder are deferring to FFMPEG or libav, as FFMPEG has a really good unencumbered AAC encoder now and libav was more than happy to rip that off. If we can remove packages, that's a good thing. I had to remove `-Wnarrowing` from FDK because it's old software and Fedora 24 has this as another hardening flag. OpenCore AMR was more for bonus points anyway, I'm not sure of its use or applicability. AAC+ might still be useful to another library, but I'm not sure.

Needs testing:
- libdvdcss
- almost everything else

The main success here is getting media playback working for the new Fedora release. The GStreamer plugins work exactly as expected from my limited testing, so :+1:.
